### PR TITLE
Fix build on Linux (invalid env_base variable)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -36,7 +36,7 @@ if platform == "osx":
 if platform == "linux":
     platform_dir = 'linux'
     env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c++14'])
-    env_base.Append(CXXFLAGS='-std=c++0x')
+    env.Append(CXXFLAGS='-std=c++0x')
 
 if platform == "windows":
     platform_dir = 'win'


### PR DESCRIPTION
The SConstruct file had an invalid reference to env_base instead of env. This fixes the build on Linux.