### PR TITLE
Set RPATH on Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -37,6 +37,7 @@ if platform == "linux":
     platform_dir = 'linux'
     env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c++14'])
     env.Append(CXXFLAGS='-std=c++0x')
+    env.Append(LINKFLAGS = ['-Wl,-R,\'$$ORIGIN\''])
 
 if platform == "windows":
     platform_dir = 'win'


### PR DESCRIPTION
Hi Bastiaan,

This adds an RPATH which points to the same directory libgodot_openvr.so is in, so libopenvr_api.so will be found automatically if both are placed in the same directory.

This brings it in line with the Windows build (and the instructions in the README), and makes it possible to launch Godot through Steam directly and have it working.