### PR TITLE
Keep aspect ratio

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -9,9 +9,10 @@ func _ready():
 		# workaround in OpenVR because OpenVR does not like our HDR buffers, so turn it off for now...
 		get_viewport().hdr = false
 		
+		# No longer needed, will remove soon. 
 		# resize our window so we see a smaller preview of our left eye
-		var size = arvr_interface.get_render_targetsize() / 3.0
-		OS.set_window_size(size);
+		# var size = arvr_interface.get_render_targetsize() / 3.0
+		# OS.set_window_size(size);
 	
 	# just for testing, list what models are available
 	var ovr_model = preload("res://bin/OpenVRRenderModel.gdns").new()

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -100,6 +100,7 @@ flags_no_depth_test = false
 flags_use_point_size = false
 flags_world_triplanar = false
 flags_fixed_size = false
+flags_albedo_tex_force_srgb = false
 vertex_color_use_as_albedo = false
 vertex_color_is_srgb = false
 params_diffuse_mode = 1

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -14,11 +14,22 @@ config/name="OpenVR demo"
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.png"
 
+[debug]
+
+settings/stdout/print_fps=true
+
+[display]
+
+window/size/width=800
+window/size/height=500
+window/vsync/use_vsync=false
+
 [gdnative]
 
 singletons=[ "res://bin/godot_openvr.gdnlib" ]
 
 [rendering]
 
+quality/voxel_cone_tracing/high_quality=false
 quality/filters/msaa=1
 environment/default_environment="res://default_env.tres"

--- a/src/GodotCalls.cpp
+++ b/src/GodotCalls.cpp
@@ -77,3 +77,13 @@ void ___godot_icall_void_int_int_bool_int_PoolByteArray(godot_method_bind *mb, g
 
 	api->godot_method_bind_ptrcall(mb, inst, args, nullptr);
 }
+
+godot_vector2 ___godot_icall_Vector2_int(godot_method_bind *mb, godot_object *inst, const int arg0) {
+	godot_vector2 ret;
+	const void *args[] = {
+		(void *) &arg0,
+	};
+
+	api->godot_method_bind_ptrcall(mb, inst, args, &ret);
+	return ret;
+}

--- a/src/GodotCalls.h
+++ b/src/GodotCalls.h
@@ -5,6 +5,37 @@
 #ifndef GODOT_CALLS_H
 #define GODOT_CALLS_H
 
+// fully define these, don't waste time with needless callbacks for access
+#define GODOT_CORE_API_GODOT_VECTOR2_TYPE_DEFINED
+typedef struct {
+	float x;
+	float y;
+
+	inline void set(float p_x, float p_y) {
+		x = p_x;
+		y = p_y;
+	};
+} godot_vector2;
+
+#define GODOT_CORE_API_GODOT_VECTOR3_TYPE_DEFINED
+typedef struct {
+	float x;
+	float y;
+	float z;
+
+	inline void set(float p_x, float p_y, float p_z) {
+		x = p_x;
+		y = p_y;
+		z = p_z;
+	};
+} godot_vector3;
+
+#define GODOT_CORE_API_GODOT_RECT2_TYPE_DEFINED
+typedef struct {
+	godot_vector2 position;
+	godot_vector2 size;
+} godot_rect2;
+
 #include <gdnative_api_struct.gen.h>
 
 #include <stdint.h>
@@ -29,10 +60,10 @@ void ___godot_icall_void_int_Object(godot_method_bind *mb, godot_object *inst, c
 void ___godot_icall_void_Color(godot_method_bind *mb, godot_object *inst, const godot_color& arg0);
 void ___godot_icall_void_Object_int(godot_method_bind *mb, godot_object *inst, const godot_object *arg0, const int arg1);
 void ___godot_icall_void_int_int_bool_int_PoolByteArray(godot_method_bind *mb, godot_object *inst, const int arg0, const int arg1, const bool arg2, const int arg3, const godot_pool_byte_array *arg4);
+godot_vector2 ___godot_icall_Vector2_int(godot_method_bind *mb, godot_object *inst, const int arg0);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* !GODOT_CALLS_H */

--- a/src/OS.cpp
+++ b/src/OS.cpp
@@ -24,3 +24,12 @@ int64_t OS_get_ticks_msec() {
 	}
 	return ___godot_icall_int(mb, (godot_object *) ___static_object_OS);
 }
+
+godot_vector2 OS_get_screen_size(const int64_t screen) {
+	OS_singleton_init();
+	static godot_method_bind *mb = NULL;
+	if (mb == NULL) {
+		mb = api->godot_method_bind_get_method("_OS", "get_screen_size");
+	}
+	return ___godot_icall_Vector2_int(mb, (godot_object *) ___static_object_OS, screen);
+}

--- a/src/OS.h
+++ b/src/OS.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 int64_t OS_get_ticks_msec();
+godot_vector2 OS_get_screen_size(const int64_t screen = -1);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
For spectator view blitting to screen now attempts to keep aspect ratio centering our render buffer.

We do this by 'zooming in' so the screen gets filled properly. We could add a switch to go into the other direction and add black bars at the side but I prefer this personally.

In the end it is just the spectator view so....